### PR TITLE
Add Ticker data extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Arquivos de Sistema Operacional (macOS, Windows, Linux)
+.DS_Store
+Thumbs.db
+ehthumbs.db
+.hidden
+._*
+
+---
+
+# Ambientes Virtuais Python
+.venv/
+venv/
+env/
+/bin/
+/include/
+/lib/
+/share/
+
+---
+
+# Bytecode Python
+*.pyc
+__pycache__/
+.Python
+build/
+develop-eggs/
+dist/
+eggs/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+---
+
+# IDEs e Editores (Exemplos comuns, adicione ou remova conforme sua IDE)
+# PyCharm
+.idea/
+.vscode/
+
+# VS Code
+.vscode/ # Geralmente já incluído, mas bom garantir
+
+# Sublime Text
+*.sublime-project
+*.sublime-workspace
+
+# Vim
+*.swp
+*.swo
+*.swn
+*.bak
+*.tmp
+*~
+
+---
+
+# Logs e Dados Gerados Automaticamente
+*.log
+*.sqlite3
+*.db
+/data/ # Se você tiver uma pasta 'data' para dados temporários/extraídos que não devem ser versionados
+*.csv  # Se os CSVs forem gerados ou baixados e não forem parte do código-fonte
+*.json # O mesmo para JSONs gerados
+
+---
+
+# Arquivos de Configuração Sensíveis (variáveis de ambiente, credenciais)
+.env
+.env.*
+config.ini
+config.yaml
+*.key
+*.pem
+
+---
+
+# Pastas de Uploads/Mídias (se sua aplicação lida com upload de arquivos)
+/media/
+/static_collected/ # Para arquivos estáticos coletados em frameworks como Django
+
+---
+
+# Dependências de Ferramentas de Build/Empacotamento
+# Pip
+pip-log.txt
+pip-delete-this-directory.txt
+
+# npm (se houver um frontend ou ferramentas JavaScript)
+node_modules/
+
+# Docker
+.dockerignore # Pode conter suas próprias regras, mas é bom listá-lo aqui para não versionar a si mesmo se estiver fora da pasta raiz
+Dockerfile.bak
+*.bak
+
+---
+
+# Notebooks Jupyter/IPython
+.ipynb_checkpoints/
+*.ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+yfinance
+numpy
+fastapi
+uvicorn

--- a/src/etl/dataExtraction.py
+++ b/src/etl/dataExtraction.py
@@ -1,0 +1,54 @@
+#Data Extraction for ETL process
+import yfinance as yf
+import pandas as pd
+from datetime import datetime, timedelta
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+def download_ticker(ticker, start_date, end_date, period, interval='1d'):
+    # Extract historical stock data from Yahoo Finance
+    
+    if not period:
+
+        logging.info(f"Using start date: {start_date}, end date: {end_date}, and interval: {interval} for ticker {ticker}")
+
+        if not start_date:
+            start_date = (datetime.now() - timedelta(days=90)).strftime('%Y-%m-%d') # Default to 3 months ago if no start date is provided
+        if not end_date:
+            end_date = datetime.now().strftime('%Y-%m-%d')
+    else:
+        start_date = None
+        end_date = None
+        logging.info(f"Using period: {period} and interval: {interval} for ticker {ticker}")
+
+
+    try:
+        yf.Ticker(ticker)
+    except Exception as e:
+        logging.error(f"Failed to initialize yfinance Ticker for {ticker}: {e}")
+        return None
+    
+    try:
+        data = yf.download(         # Download historical data for the ticker
+            ticker,
+            start=start_date,
+            end=end_date,
+            period=period,
+            interval=interval,
+            auto_adjust=True,
+        )
+    except Exception as e:
+        logging.error(f"Failed to download data for {ticker} from Yahoo Finance: {e}")
+        return None
+    
+    df = pd.DataFrame(data)  # Convert the data to a DataFrame
+    
+    if df.empty:
+        logging.warning(f"No data found for {ticker} in the specified date range.")
+        return None
+    else:
+        return df
+
+df = download_ticker('aapl', None, None, '1y', '1d')
+print(df.head())  # Display the first rows of the DataFrame

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,1 @@
+#Application entry point


### PR DESCRIPTION
# Adicionar módulo de extração de Tickers financeiros

---

### O que esta PR faz?
Esta PR implementa a **extração inicial de dados financeiros** do Yahoo Finance usando `yfinance`, estabelecendo a primeira etapa do pipeline ETL.

---

### Como Testar
1.  **Faça o checkout da branch**: `git checkout <feature/data_extraction>`
2.  **Instale dependências**: `pip install -r /requirements.txt`
3.  **Execute o script**: `/src/etl/data_extraction.py`
4.  **Verifique a saída**: Observe os logs no terminal para a extração de dados da `AAPL` e o erro para o ticker inválido.

---

### Tipo de Mudança
*(Marque um X. Exclua os outros tipos.)*
- [X] Nova funcionalidade (`feat`)
- [ ] Correção de bug (`fix`)
- [ ] Refatoração (`refactor`)
- [ ] Outros (especifique):